### PR TITLE
Stale device cleanup, log spam reduction, and setup performance

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from . import maveo_box
 from .const import DOMAIN
+from .dynamic_mapper import generate_entities_for_thing_class
 from .maveo_stick import MaveoStick
 from .thing import Thing
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[str] = ["cover", "sensor", "binary_sensor", "switch", "button"]
 
@@ -51,13 +57,63 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await MaveoStick.add(nymea_hub)
     await Thing.add(nymea_hub)
 
+    # Pre-compute entity configs once; all platforms read from nymea_hub.entity_configs.
+    entity_configs: dict[str, list] = {
+        "sensors": [],
+        "binary_sensors": [],
+        "switches": [],
+        "buttons": [],
+    }
+    for thing_class in nymea_hub.thing_classes:
+        configs = generate_entities_for_thing_class(thing_class)
+        for key in entity_configs:
+            entity_configs[key].extend(configs[key])
+    nymea_hub.entity_configs = entity_configs
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Remove devices from HA registry that no longer exist in the nymea hub.
+    _cleanup_stale_devices(hass, entry, nymea_hub)
 
     # Start notification listener AFTER all entities are set up.
     # This prevents blocking during initialization.
     nymea_hub.start_notification_listener()
 
     return True
+
+
+def _cleanup_stale_devices(
+    hass: HomeAssistant, entry: ConfigEntry, nymea_hub: maveo_box.MaveoBox
+) -> None:
+    """Remove devices from HA registry that no longer exist in the nymea hub."""
+    device_registry = dr.async_get(hass)
+
+    current_thing_ids = {thing.id for thing in nymea_hub.things}
+    current_thing_ids.update(stick.id for stick in nymea_hub.maveoSticks)
+
+    _LOGGER.debug("Current thing IDs from hub: %s", current_thing_ids)
+
+    registered_devices = dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    )
+    _LOGGER.debug("Registered devices for config entry: %d", len(registered_devices))
+
+    for device in registered_devices:
+        device_thing_ids = {
+            identifier[1]
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+        }
+        _LOGGER.debug(
+            "Device '%s' has nymea identifiers: %s", device.name, device_thing_ids
+        )
+        if not device_thing_ids.intersection(current_thing_ids):
+            _LOGGER.info(
+                "Removing stale device '%s' (%s) from registry",
+                device.name,
+                device.id,
+            )
+            device_registry.async_remove_device(device.id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .dynamic_mapper import generate_entities_for_thing_class
 from .thing import Thing
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,14 +28,9 @@ async def async_setup_entry(
     """Add binary sensors for passed config_entry in HA."""
     maveoBox = config_entry.runtime_data
 
-    # Generate dynamic binary sensor configurations from discovered thing classes
-    binary_sensor_configs = []
-    for thing_class in maveoBox.thing_classes:
-        entities = generate_entities_for_thing_class(thing_class)
-        binary_sensor_configs.extend(entities["binary_sensors"])
-
-    _LOGGER.info(
-        "Generated %d dynamic binary sensor configurations", len(binary_sensor_configs)
+    binary_sensor_configs = maveoBox.entity_configs["binary_sensors"]
+    _LOGGER.debug(
+        "Using %d pre-computed binary sensor configurations", len(binary_sensor_configs)
     )
 
     # Create binary sensors for all things that match the thing class IDs

--- a/button.py
+++ b/button.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .dynamic_mapper import generate_entities_for_thing_class
 from .thing import Thing
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,13 +25,8 @@ async def async_setup_entry(
     """Add buttons for passed config_entry in HA."""
     maveoBox = config_entry.runtime_data
 
-    # Generate dynamic button configurations from discovered thing classes
-    button_configs = []
-    for thing_class in maveoBox.thing_classes:
-        entities = generate_entities_for_thing_class(thing_class)
-        button_configs.extend(entities["buttons"])
-
-    _LOGGER.info("Generated %d dynamic button configurations", len(button_configs))
+    button_configs = maveoBox.entity_configs["buttons"]
+    _LOGGER.debug("Using %d pre-computed button configurations", len(button_configs))
 
     # Create buttons for all things that match the thing class IDs
     new_devices = []

--- a/dynamic_mapper.py
+++ b/dynamic_mapper.py
@@ -225,11 +225,11 @@ def generate_entities_for_thing_class(
                     if action.get("id") != state_type_id
                 ]
 
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "State '%s' (ID: %s) - Found %d matching actions, %d parameterized",
                     display_name, state_type_id, len(matching_actions), len(parameterized_actions)
                 )
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Matching actions: %s",
                     [{"id": a.get("id"), "name": a.get("name", a.get("displayName"))}
                      for a in matching_actions]
@@ -238,14 +238,14 @@ def generate_entities_for_thing_class(
                 if parameterized_actions:
                     # Use the parameterized action (different ID from state)
                     action_type_id = parameterized_actions[0].get("id")
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Creating switch for '%s' with parameterized action ID: %s (state ID: %s)",
                         display_name, action_type_id, state_type_id
                     )
                 else:
                     # Fall back to toggle action (same ID as state)
                     action_type_id = matching_actions[0].get("id")
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Creating switch for '%s' with toggle action ID: %s (state ID: %s)",
                         display_name, action_type_id, state_type_id
                     )

--- a/sensor.py
+++ b/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .dynamic_mapper import generate_entities_for_thing_class
 from .thing import Thing
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,13 +29,8 @@ async def async_setup_entry(
     """Add sensors for passed config_entry in HA."""
     maveoBox = config_entry.runtime_data
 
-    # Generate dynamic sensor configurations from discovered thing classes
-    sensor_configs = []
-    for thing_class in maveoBox.thing_classes:
-        entities = generate_entities_for_thing_class(thing_class)
-        sensor_configs.extend(entities["sensors"])
-
-    _LOGGER.info("Generated %d dynamic sensor configurations", len(sensor_configs))
+    sensor_configs = maveoBox.entity_configs["sensors"]
+    _LOGGER.debug("Using %d pre-computed sensor configurations", len(sensor_configs))
 
     # Create sensors for all things that match the thing class IDs
     new_devices = []

--- a/switch.py
+++ b/switch.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .dynamic_mapper import generate_entities_for_thing_class
 from .thing import Thing
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,13 +25,8 @@ async def async_setup_entry(
     """Add switches for passed config_entry in HA."""
     maveoBox = config_entry.runtime_data
 
-    # Generate dynamic switch configurations from discovered thing classes
-    switch_configs = []
-    for thing_class in maveoBox.thing_classes:
-        entities = generate_entities_for_thing_class(thing_class)
-        switch_configs.extend(entities["switches"])
-
-    _LOGGER.info("Generated %d dynamic switch configurations", len(switch_configs))
+    switch_configs = maveoBox.entity_configs["switches"]
+    _LOGGER.debug("Using %d pre-computed switch configurations", len(switch_configs))
 
     # Create switches for all things that match the thing class IDs
     new_devices = []
@@ -131,14 +125,14 @@ class DynamicThingSwitch(SwitchEntity):
             )
 
             # Log what we discovered about this action
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Turn ON - Full action type definition for %s: %s",
                 self._thing.name, action_type
             )
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Turn ON - Action ID we're looking for: %s", self._actionTypeId_on
             )
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Turn ON - All available action types: %s",
                 [{"id": at.get("id"), "name": at.get("name", at.get("displayName")),
                   "paramTypes": at.get("paramTypes", [])} for at in action_types]
@@ -158,16 +152,16 @@ class DynamicThingSwitch(SwitchEntity):
                     param_id = param_type.get("id")
                     param_name = param_type.get("name")
                     param_type_type = param_type.get("type", "unknown")
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Turn ON - Param type found: id=%s, name=%s, type=%s",
                         param_id, param_name, param_type_type
                     )
                     # For Nymea API, use paramTypeId (the parameter ID) and value
                     param_list.append({"paramTypeId": param_id, "value": True})
                 exec_params["params"] = param_list
-                _LOGGER.warning("Turn ON - Built params: %s", exec_params["params"])
+                _LOGGER.debug("Turn ON - Built params: %s", exec_params["params"])
             else:
-                _LOGGER.warning("Turn ON - No parameters required for this action")
+                _LOGGER.debug("Turn ON - No parameters required for this action")
 
             # Execute the action and wait for response
             result = await self.hass.async_add_executor_job(
@@ -176,8 +170,8 @@ class DynamicThingSwitch(SwitchEntity):
                 exec_params,
             )
 
-            _LOGGER.warning("Turn ON - Execution params sent: %s", exec_params)
-            _LOGGER.warning("Turn ON - Result received: %s", result)
+            _LOGGER.debug("Turn ON - Execution params sent: %s", exec_params)
+            _LOGGER.debug("Turn ON - Result received: %s", result)
 
             if result is None:
                 _LOGGER.error("Failed to execute turn_on action for %s", self._thing.name)
@@ -219,11 +213,11 @@ class DynamicThingSwitch(SwitchEntity):
             )
 
             # Log what we discovered about this action
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Turn OFF - Full action type definition for %s: %s",
                 self._thing.name, action_type
             )
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Turn OFF - Action ID we're looking for: %s", self._actionTypeId_off
             )
 
@@ -241,16 +235,16 @@ class DynamicThingSwitch(SwitchEntity):
                     param_id = param_type.get("id")
                     param_name = param_type.get("name")
                     param_type_type = param_type.get("type", "unknown")
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Turn OFF - Param type found: id=%s, name=%s, type=%s",
                         param_id, param_name, param_type_type
                     )
                     # For Nymea API, use paramTypeId (the parameter ID) and value
                     param_list.append({"paramTypeId": param_id, "value": False})
                 exec_params["params"] = param_list
-                _LOGGER.warning("Turn OFF - Built params: %s", exec_params["params"])
+                _LOGGER.debug("Turn OFF - Built params: %s", exec_params["params"])
             else:
-                _LOGGER.warning("Turn OFF - No parameters required for this action")
+                _LOGGER.debug("Turn OFF - No parameters required for this action")
 
             # Execute the action and wait for response
             result = await self.hass.async_add_executor_job(
@@ -259,8 +253,8 @@ class DynamicThingSwitch(SwitchEntity):
                 exec_params,
             )
 
-            _LOGGER.warning("Turn OFF - Execution params sent: %s", exec_params)
-            _LOGGER.warning("Turn OFF - Result received: %s", result)
+            _LOGGER.debug("Turn OFF - Execution params sent: %s", exec_params)
+            _LOGGER.debug("Turn OFF - Result received: %s", result)
 
             if result is None:
                 _LOGGER.error("Failed to execute turn_off action for %s", self._thing.name)


### PR DESCRIPTION
## Description
Home Assistant does not automatically remove devices from the device registry when they are deleted in the Maveo Box. After reloading the integration, orphaned entries persisted indefinitely.

**Fix in __init__.py:** After all platforms are set up, _cleanup_stale_devices() compares the registered HA devices against the thing IDs currently reported by the hub. Any device whose ID is no longer present in the hub is removed from the registry.

--- 
Log spam due to wrong log levels. WARNING instead of DEBUG

dynamic_mapper.py: _LOGGER.warning() during switch entity generation → _LOGGER.debug()
switch.py: _LOGGER.warning() in async_turn_on / async_turn_off (leftover debug traces from developing the switch action API) → _LOGGER.debug()

---
generate_entities_for_thing_class() was called 4× per setup
Each of the four platforms (sensor, binary_sensor, switch, button) independently called generate_entities_for_thing_class() for every thing class — resulting in 4* redundant computation and log output.

**Fix __init__.py + all 4 platform files:** The function is now called once during async_setup_entry and the result is cached as nymea_hub.entity_configs. Each platform reads from this cache instead of invoking the function itself.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Code quality improvements

## Checklist

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

## Testing
There are no unit test results, cause of Python 3.14 - the current homeassistant version pins lru-dict==1.3.0, whose C extension has no pre-built wheel for Python 3.14 and fails to compile.

All the added and change parts are tested in my own production system

## Related Issues
<!-- Link any related issues here using #issue_number -->

Fixes #
